### PR TITLE
Fixing SQL error when saving logging and using different locale settings

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -2133,7 +2133,7 @@ abstract class REST_Controller extends CI_Controller {
      */
     protected function _log_access_time()
     {
-        $payload['rtime'] = $this->_end_rtime - $this->_start_rtime;
+        $payload['rtime'] = str_replace(',', '.', $this->_end_rtime - $this->_start_rtime);
 
         return $this->rest->db->update(
                 $this->config->item('rest_logs_table'), $payload, [


### PR DESCRIPTION
When using localization where decimals are represented with comma instead of a dot, the subtraction of request end time and start time results in a decimal with a comma and this will cause a sql error on inserting to the log table. Therefore, ensure that a comma in the resulting decimal of $payload['rtime'] is converted to a dot.